### PR TITLE
Add test for abstract methods (abstract class & interface).

### DIFF
--- a/src/test/resources/gr/gousiosg/javacg/abstract.feature
+++ b/src/test/resources/gr/gousiosg/javacg/abstract.feature
@@ -1,0 +1,24 @@
+#Author: matthieu.vergne@gmail.com
+Feature: Abstract
+  I want to identify all abstract methods within the analyzed code.
+
+  Scenario: Retrieve abstract method call
+    Given I have the class "MyAbstract" with code:
+      """
+      public abstract class MyAbstract {
+       public abstract void doSomething();
+      }
+      """
+    Given I have the class "AbstractTest" with code:
+      """
+      public class AbstractTest {
+       public void execute(MyAbstract x) {
+        x.doSomething();
+       }
+      }
+      """
+    When I run the analyze
+    Then the result should contain:
+      """
+      M:AbstractTest:execute(MyAbstract) (M)MyAbstract:doSomething()
+      """

--- a/src/test/resources/gr/gousiosg/javacg/interface.feature
+++ b/src/test/resources/gr/gousiosg/javacg/interface.feature
@@ -1,0 +1,24 @@
+#Author: matthieu.vergne@gmail.com
+Feature: Interface
+  I want to identify all interface methods within the analyzed code.
+
+  Scenario: Retrieve interface method call
+    Given I have the class "MyInterface" with code:
+      """
+      public interface MyInterface {
+       public void doSomething();
+      }
+      """
+    Given I have the class "InterfaceTest" with code:
+      """
+      public class InterfaceTest {
+       public void execute(MyInterface x) {
+        x.doSomething();
+       }
+      }
+      """
+    When I run the analyze
+    Then the result should contain:
+      """
+      M:InterfaceTest:execute(MyInterface) (I)MyInterface:doSomething()
+      """


### PR DESCRIPTION
I just confirmed that the `isAbstract()` condition covers both interfaces & abstract classes (if you remove it, both tests fail).