### PR TITLE
zip files as input for javacg

### DIFF
--- a/src/main/java/gr/gousiosg/javacg/stat/JCallGraph.java
+++ b/src/main/java/gr/gousiosg/javacg/stat/JCallGraph.java
@@ -31,10 +31,10 @@ package gr.gousiosg.javacg.stat;
 import java.io.*;
 import java.util.*;
 import java.util.function.Function;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.apache.bcel.classfile.ClassParser;
 
@@ -66,8 +66,8 @@ public class JCallGraph {
                     System.err.println("Jar file " + arg + " does not exist");
                 }
 
-                try (JarFile jar = new JarFile(f)) {
-                    Stream<JarEntry> entries = enumerationAsStream(jar.entries());
+                try (ZipFile jar = new ZipFile(f)) {
+                    Stream<? extends ZipEntry> entries = enumerationAsStream(jar.entries());
 
                     String methodCalls = entries.
                             flatMap(e -> {


### PR DESCRIPTION
Some projects run with managers like maven or gradle and does not generate jar files.
In order to extract their callgraphs I zip the compiled files with `zip -r classes.zip $(find -iname *.class)` and provide it as input for javacg static tool.