### PR TITLE
Fix IndexOutOfBoundsException in DynamicCallManager

### DIFF
--- a/src/main/java/gr/gousiosg/javacg/stat/DynamicCallManager.java
+++ b/src/main/java/gr/gousiosg/javacg/stat/DynamicCallManager.java
@@ -81,6 +81,9 @@ public class DynamicCallManager {
         while (matcher.find()) {
             int bootIndex = Integer.parseInt(matcher.group(1));
             BootstrapMethod bootMethod = boots[bootIndex];
+            if (bootMethod.getBootstrapArguments().length < 2) {
+                continue;
+            }
             int calledIndex = bootMethod.getBootstrapArguments()[CALL_HANDLE_INDEX_ARGUMENT];
             String calledName = getMethodNameFromHandleIndex(cp, calledIndex);
             String callerName = method.getName();


### PR DESCRIPTION
`bootMethod.getBootstrapArguments()` can return less than 2 elements, resulting in `IndexOutOfBoundsException`.